### PR TITLE
Fix chart objects from crashing in js when referenced after instantiation

### DIFF
--- a/rust/src/wrapper/chart/chart_data_label.rs
+++ b/rust/src/wrapper/chart/chart_data_label.rs
@@ -6,6 +6,7 @@ use crate::wrapper::chart::chart_font::ChartFont;
 use crate::wrapper::chart::chart_format::ChartFormat;
 
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct ChartDataLabel {
     pub(crate) inner: xlsx::ChartDataLabel,
 }
@@ -20,99 +21,99 @@ impl ChartDataLabel {
     }
 
     #[wasm_bindgen(js_name = "showValue")]
-    pub fn show_value(mut self) -> ChartDataLabel {
+    pub fn show_value(&mut self) -> ChartDataLabel {
         self.inner.show_value();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "showCategoryName")]
-    pub fn show_category_name(mut self) -> ChartDataLabel {
+    pub fn show_category_name(&mut self) -> ChartDataLabel {
         self.inner.show_category_name();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "showSeriesName")]
-    pub fn show_series_name(mut self) -> ChartDataLabel {
+    pub fn show_series_name(&mut self) -> ChartDataLabel {
         self.inner.show_series_name();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "showLeaderLines")]
-    pub fn show_leader_lines(mut self) -> ChartDataLabel {
+    pub fn show_leader_lines(&mut self) -> ChartDataLabel {
         self.inner.show_leader_lines();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "showLegendKey")]
-    pub fn show_legend_key(mut self) -> ChartDataLabel {
+    pub fn show_legend_key(&mut self) -> ChartDataLabel {
         self.inner.show_legend_key();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "showPercentage")]
-    pub fn show_percentage(mut self) -> ChartDataLabel {
+    pub fn show_percentage(&mut self) -> ChartDataLabel {
         self.inner.show_percentage();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setPosition")]
-    pub fn set_position(mut self, position: ChartDataLabelPosition) -> ChartDataLabel {
+    pub fn set_position(&mut self, position: ChartDataLabelPosition) -> ChartDataLabel {
         self.inner.set_position(position.into());
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setFont")]
-    pub fn set_font(mut self, font: &ChartFont) -> ChartDataLabel {
+    pub fn set_font(&mut self, font: &ChartFont) -> ChartDataLabel {
         self.inner.set_font(&font.inner);
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setFormat")]
-    pub fn set_format(mut self, format: &mut ChartFormat) -> ChartDataLabel {
+    pub fn set_format(&mut self, format: &mut ChartFormat) -> ChartDataLabel {
         self.inner.set_format(&mut format.inner);
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setNumFormat")]
-    pub fn set_num_format(mut self, num_format: &str) -> ChartDataLabel {
+    pub fn set_num_format(&mut self, num_format: &str) -> ChartDataLabel {
         self.inner.set_num_format(num_format);
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setSeparator")]
-    pub fn set_separator(mut self, separator: char) -> ChartDataLabel {
+    pub fn set_separator(&mut self, separator: char) -> ChartDataLabel {
         self.inner.set_separator(separator);
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "showYValue")]
-    pub fn show_y_value(mut self) -> ChartDataLabel {
+    pub fn show_y_value(&mut self) -> ChartDataLabel {
         self.inner.show_y_value();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "showXValue")]
-    pub fn show_x_value(mut self) -> ChartDataLabel {
+    pub fn show_x_value(&mut self) -> ChartDataLabel {
         self.inner.show_x_value();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setHidden")]
-    pub fn set_hidden(mut self) -> ChartDataLabel {
+    pub fn set_hidden(&mut self) -> ChartDataLabel {
         self.inner.set_hidden();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setValue")]
-    pub fn set_value(mut self, value: &str) -> ChartDataLabel {
+    pub fn set_value(&mut self, value: &str) -> ChartDataLabel {
         self.inner.set_value(value);
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "toCustom")]
-    pub fn to_custom(mut self) -> ChartDataLabel {
+    pub fn to_custom(&mut self) -> ChartDataLabel {
         self.inner.to_custom();
-        self
+        self.clone()
     }
 }
 

--- a/rust/src/wrapper/chart/chart_font.rs
+++ b/rust/src/wrapper/chart/chart_font.rs
@@ -10,6 +10,7 @@ use crate::wrapper::color::Color;
 ///
 /// It is used in conjunction with the {@link Chart} struct.
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct ChartFont {
     pub(crate) inner: xlsx::ChartFont,
 }
@@ -28,9 +29,9 @@ impl ChartFont {
     ///
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setBold")]
-    pub fn set_bold(mut self) -> ChartFont {
+    pub fn set_bold(&mut self) -> ChartFont {
         self.inner.set_bold();
-        self
+        self.clone()
     }
 
     /// Set the font character set value.
@@ -41,9 +42,9 @@ impl ChartFont {
     /// @param {number} charset - The font character set value.
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setCharacterSet")]
-    pub fn set_character_set(mut self, character_set: u8) -> ChartFont {
+    pub fn set_character_set(&mut self, character_set: u8) -> ChartFont {
         self.inner.set_character_set(character_set);
-        self
+        self.clone()
     }
 
     /// Set the font color property.
@@ -51,18 +52,18 @@ impl ChartFont {
     /// @param {Color} color - The font color property.
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setColor")]
-    pub fn set_color(mut self, color: &Color) -> ChartFont {
+    pub fn set_color(&mut self, color: &Color) -> ChartFont {
         self.inner.set_color(color.inner);
-        self
+        self.clone()
     }
 
     /// Set the font italic property.
     ///
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setItalic")]
-    pub fn set_italic(mut self) -> ChartFont {
+    pub fn set_italic(&mut self) -> ChartFont {
         self.inner.set_italic();
-        self
+        self.clone()
     }
 
     /// Set the font name/family property.
@@ -74,9 +75,9 @@ impl ChartFont {
     /// @param {string} name - The font name property.
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setName")]
-    pub fn set_name(mut self, name: &str) -> ChartFont {
+    pub fn set_name(&mut self, name: &str) -> ChartFont {
         self.inner.set_name(name);
-        self
+        self.clone()
     }
 
     /// Set the font pitch and family value.
@@ -87,9 +88,9 @@ impl ChartFont {
     /// @param {number} pitch_family - The font pitch and family value.
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setPitchFamily")]
-    pub fn set_pitch_family(mut self, pitch_family: u8) -> ChartFont {
+    pub fn set_pitch_family(&mut self, pitch_family: u8) -> ChartFont {
         self.inner.set_pitch_family(pitch_family);
-        self
+        self.clone()
     }
 
     /// Set the right to left property.
@@ -100,9 +101,9 @@ impl ChartFont {
     /// @param {boolean} enable - Turn the property on/off. Defaults to true.
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setRightToLeft")]
-    pub fn set_right_to_left(mut self, enable: bool) -> ChartFont {
+    pub fn set_right_to_left(&mut self, enable: bool) -> ChartFont {
         self.inner.set_right_to_left(enable);
-        self
+        self.clone()
     }
 
     /// Set the font rotation angle.
@@ -112,9 +113,9 @@ impl ChartFont {
     /// @param {number} rotation - The rotation angle in degrees.
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setRotation")]
-    pub fn set_rotation(mut self, rotation: i16) -> ChartFont {
+    pub fn set_rotation(&mut self, rotation: i16) -> ChartFont {
         self.inner.set_rotation(rotation);
-        self
+        self.clone()
     }
 
     /// Set the font size property.
@@ -124,9 +125,9 @@ impl ChartFont {
     /// @param {number} size - The font size property.
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setSize")]
-    pub fn set_size(mut self, size: f64) -> ChartFont {
+    pub fn set_size(&mut self, size: f64) -> ChartFont {
         self.inner.set_size(size);
-        self
+        self.clone()
     }
 
     /// Set the font strikethrough property.
@@ -136,9 +137,9 @@ impl ChartFont {
     ///
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setStrikethrough")]
-    pub fn set_strikethrough(mut self) -> ChartFont {
+    pub fn set_strikethrough(&mut self) -> ChartFont {
         self.inner.set_strikethrough();
-        self
+        self.clone()
     }
 
     /// Set the font underline property.
@@ -149,9 +150,9 @@ impl ChartFont {
     /// @param {number} underline - The font underline value.
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "setUnderline")]
-    pub fn set_underline(mut self) -> ChartFont {
+    pub fn set_underline(&mut self) -> ChartFont {
         self.inner.set_underline();
-        self
+        self.clone()
     }
 
     /// Unset bold property.
@@ -161,8 +162,8 @@ impl ChartFont {
     ///
     /// @return {ChartFont} - The ChartFont instance.
     #[wasm_bindgen(js_name = "unsetBold")]
-    pub fn unset_bold(mut self) -> ChartFont {
+    pub fn unset_bold(&mut self) -> ChartFont {
         self.inner.unset_bold();
-        self
+        self.clone()
     }
 }

--- a/rust/src/wrapper/chart/chart_format.rs
+++ b/rust/src/wrapper/chart/chart_format.rs
@@ -1,7 +1,6 @@
 use rust_xlsxwriter::{self as xlsx};
 use wasm_bindgen::prelude::*;
-
-use crate::wrapper::color::Color;
+use crate::wrapper::chart::chart_line::ChartLine;
 use crate::wrapper::chart::chart_solid_fill::ChartSolidFill;
 
 /// The `ChartFormat` struct represents formatting for various chart objects.
@@ -36,6 +35,7 @@ use crate::wrapper::chart::chart_solid_fill::ChartSolidFill;
 ///
 /// TODO: example omitted
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct ChartFormat {
     pub(crate) inner: xlsx::ChartFormat,
 }
@@ -51,155 +51,39 @@ impl ChartFormat {
     }
 
     #[wasm_bindgen(js_name = "setLine")]
-    pub fn set_line(mut self, line: &ChartLine) -> ChartFormat {
+    pub fn set_line(&mut self, line: &ChartLine) -> ChartFormat {
         self.inner.set_line(&line.inner);
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setBorder")]
-    pub fn set_border(mut self, border: &ChartLine) -> ChartFormat {
+    pub fn set_border(&mut self, border: &ChartLine) -> ChartFormat {
         self.inner.set_border(&border.inner);
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setNoLine")]
-    pub fn set_no_line(mut self) -> ChartFormat {
+    pub fn set_no_line(&mut self) -> ChartFormat {
         self.inner.set_no_line();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setNoBorder")]
-    pub fn set_no_border(mut self) -> ChartFormat {
+    pub fn set_no_border(&mut self) -> ChartFormat {
         self.inner.set_no_border();
-        self
+        self.clone()
     }
 
     #[wasm_bindgen(js_name = "setNoFill")]
-    pub fn set_no_fill(mut self) -> ChartFormat {
+    pub fn set_no_fill(&mut self) -> ChartFormat {
         self.inner.set_no_fill();
-        self
+        self.clone()
     }
 
     // TODO: set_gradient_fill, set_pattern_fill
     #[wasm_bindgen(js_name = "setSolidFill")]
-    pub fn set_solid_fill(mut self, fill: &ChartSolidFill) -> ChartFormat {
+    pub fn set_solid_fill(&mut self, fill: &ChartSolidFill) -> ChartFormat {
         self.inner.set_solid_fill(&fill.inner);
-        self
-    }
-}
-
-/// The `ChartLine` struct represents a chart line/border.
-///
-/// The `ChartLine` struct represents the formatting properties for a line or
-/// border for a Chart element. It is a sub property of the {@link ChartFormat}
-/// struct and is used with the {@link ChartFormat#setLine} or
-/// {@link ChartFormat#setBorder} methods.
-///
-/// Excel uses the element names "Line" and "Border" depending on the context.
-/// For a Line chart the line is represented by a line property but for a Column
-/// chart the line becomes the border. Both of these share the same properties
-/// and are both represented in `rust_xlsxwriter` by the {@link ChartLine} struct.
-///
-/// As a syntactic shortcut you can use the type alias {@link ChartBorder} instead
-/// of `ChartLine`.
-///
-/// It is used in conjunction with the {@link Chart} struct.
-///
-/// TODO: example omitted
-#[wasm_bindgen]
-pub struct ChartLine {
-    pub(crate) inner: xlsx::ChartLine,
-}
-
-#[wasm_bindgen]
-impl ChartLine {
-    /// Create a new `ChartLine` instance to set formatting for a chart line.
-    #[wasm_bindgen(constructor)]
-    pub fn new() -> ChartLine {
-        ChartLine {
-            inner: xlsx::ChartLine::new(),
-        }
-    }
-
-    #[wasm_bindgen(js_name = "setColor")]
-    pub fn set_color(mut self, color: &Color) -> ChartLine {
-        self.inner.set_color(color.inner);
-        self
-    }
-
-    #[wasm_bindgen(js_name = "setWidth")]
-    pub fn set_width(mut self, width: f64) -> ChartLine {
-        self.inner.set_width(width);
-        self
-    }
-
-    #[wasm_bindgen(js_name = "setDashType")]
-    pub fn set_dash_type(mut self, dash_type: ChartLineDashType) -> ChartLine {
-        self.inner.set_dash_type(dash_type.into());
-        self
-    }
-
-    #[wasm_bindgen(js_name = "setTransparency")]
-    pub fn set_transparency(mut self, transparency: u8) -> ChartLine {
-        self.inner.set_transparency(transparency);
-        self
-    }
-
-    #[wasm_bindgen(js_name = "setHidden")]
-    pub fn set_hidden(mut self, enable: bool) -> ChartLine {
-        self.inner.set_hidden(enable);
-        self
-    }
-}
-
-#[derive(Clone, Copy)]
-#[wasm_bindgen]
-pub enum ChartLineDashType {
-    /// Solid - chart line/border dash type.
-    ///
-    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_solid.png">
-    Solid,
-    /// Round dot - chart line/border dash type.
-    ///
-    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_round_dot.png">
-    RoundDot,
-    /// Square dot - chart line/border dash type.
-    ///
-    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_square_dot.png">
-    SquareDot,
-    /// Dash - chart line/border dash type.
-    ///
-    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_dash.png">
-    Dash,
-    /// Dash dot - chart line/border dash type.
-    ///
-    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_dash_dot.png">
-    DashDot,
-    /// Long dash - chart line/border dash type.
-    ///
-    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_longdash.png">
-    LongDash,
-    /// Long dash dot - chart line/border dash type.
-    ///
-    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_longdash_dot.png">
-    LongDashDot,
-    /// Long dash dot dot - chart line/border dash type.
-    ///
-    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_longdash_dot_dot.png">
-    LongDashDotDot,
-}
-
-impl From<ChartLineDashType> for xlsx::ChartLineDashType {
-    fn from(value: ChartLineDashType) -> Self {
-        match value {
-            ChartLineDashType::Solid => xlsx::ChartLineDashType::Solid,
-            ChartLineDashType::RoundDot => xlsx::ChartLineDashType::RoundDot,
-            ChartLineDashType::SquareDot => xlsx::ChartLineDashType::SquareDot,
-            ChartLineDashType::Dash => xlsx::ChartLineDashType::Dash,
-            ChartLineDashType::DashDot => xlsx::ChartLineDashType::DashDot,
-            ChartLineDashType::LongDash => xlsx::ChartLineDashType::LongDash,
-            ChartLineDashType::LongDashDot => xlsx::ChartLineDashType::LongDashDot,
-            ChartLineDashType::LongDashDotDot => xlsx::ChartLineDashType::LongDashDotDot,
-        }
+        self.clone()
     }
 }

--- a/rust/src/wrapper/chart/chart_line.rs
+++ b/rust/src/wrapper/chart/chart_line.rs
@@ -1,0 +1,120 @@
+use rust_xlsxwriter::{self as xlsx};
+use wasm_bindgen::prelude::wasm_bindgen;
+use crate::wrapper::color::Color;
+
+/// The `ChartLine` struct represents a chart line/border.
+///
+/// The `ChartLine` struct represents the formatting properties for a line or
+/// border for a Chart element. It is a sub property of the {@link ChartFormat}
+/// struct and is used with the {@link ChartFormat#setLine} or
+/// {@link ChartFormat#setBorder} methods.
+///
+/// Excel uses the element names "Line" and "Border" depending on the context.
+/// For a Line chart the line is represented by a line property but for a Column
+/// chart the line becomes the border. Both of these share the same properties
+/// and are both represented in `rust_xlsxwriter` by the {@link ChartLine} struct.
+///
+/// As a syntactic shortcut you can use the type alias {@link ChartBorder} instead
+/// of `ChartLine`.
+///
+/// It is used in conjunction with the {@link Chart} struct.
+///
+/// TODO: example omitted
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct ChartLine {
+    pub(crate) inner: xlsx::ChartLine,
+}
+
+#[wasm_bindgen]
+impl ChartLine {
+    /// Create a new `ChartLine` instance to set formatting for a chart line.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> ChartLine {
+        ChartLine {
+            inner: xlsx::ChartLine::new(),
+        }
+    }
+
+    #[wasm_bindgen(js_name = "setColor")]
+    pub fn set_color(&mut self, color: &Color) -> ChartLine {
+        self.inner.set_color(color.inner);
+        self.clone()
+    }
+
+    #[wasm_bindgen(js_name = "setWidth")]
+    pub fn set_width(&mut self, width: f64) -> ChartLine {
+        self.inner.set_width(width);
+        self.clone()
+    }
+
+    #[wasm_bindgen(js_name = "setDashType")]
+    pub fn set_dash_type(&mut self, dash_type: ChartLineDashType) -> ChartLine {
+        self.inner.set_dash_type(dash_type.into());
+        self.clone()
+    }
+
+    #[wasm_bindgen(js_name = "setTransparency")]
+    pub fn set_transparency(&mut self, transparency: u8) -> ChartLine {
+        self.inner.set_transparency(transparency);
+        self.clone()
+    }
+
+    #[wasm_bindgen(js_name = "setHidden")]
+    pub fn set_hidden(&mut self, enable: bool) -> ChartLine {
+        self.inner.set_hidden(enable);
+        self.clone()
+    }
+}
+
+#[derive(Clone, Copy)]
+#[wasm_bindgen]
+pub enum ChartLineDashType {
+    /// Solid - chart line/border dash type.
+    ///
+    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_solid.png">
+    Solid,
+    /// Round dot - chart line/border dash type.
+    ///
+    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_round_dot.png">
+    RoundDot,
+    /// Square dot - chart line/border dash type.
+    ///
+    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_square_dot.png">
+    SquareDot,
+    /// Dash - chart line/border dash type.
+    ///
+    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_dash.png">
+    Dash,
+    /// Dash dot - chart line/border dash type.
+    ///
+    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_dash_dot.png">
+    DashDot,
+    /// Long dash - chart line/border dash type.
+    ///
+    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_longdash.png">
+    LongDash,
+    /// Long dash dot - chart line/border dash type.
+    ///
+    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_longdash_dot.png">
+    LongDashDot,
+    /// Long dash dot dot - chart line/border dash type.
+    ///
+    /// <img src="https://rustxlsxwriter.github.io/images/chart_line_dash_longdash_dot_dot.png">
+    LongDashDotDot,
+}
+
+impl From<ChartLineDashType> for xlsx::ChartLineDashType {
+    fn from(value: ChartLineDashType) -> Self {
+        match value {
+            ChartLineDashType::Solid => xlsx::ChartLineDashType::Solid,
+            ChartLineDashType::RoundDot => xlsx::ChartLineDashType::RoundDot,
+            ChartLineDashType::SquareDot => xlsx::ChartLineDashType::SquareDot,
+            ChartLineDashType::Dash => xlsx::ChartLineDashType::Dash,
+            ChartLineDashType::DashDot => xlsx::ChartLineDashType::DashDot,
+            ChartLineDashType::LongDash => xlsx::ChartLineDashType::LongDash,
+            ChartLineDashType::LongDashDot => xlsx::ChartLineDashType::LongDashDot,
+            ChartLineDashType::LongDashDotDot => xlsx::ChartLineDashType::LongDashDotDot,
+        }
+    }
+}

--- a/rust/src/wrapper/chart/chart_marker.rs
+++ b/rust/src/wrapper/chart/chart_marker.rs
@@ -5,6 +5,7 @@ use crate::wrapper::chart::chart_format::ChartFormat;
 use crate::wrapper::chart::chart_marker_type::ChartMarkerType;
 
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct ChartMarker {
     pub(crate) inner: xlsx::ChartMarker,
 }
@@ -24,9 +25,9 @@ impl ChartMarker {
     ///
     /// @return {ChartMarker} - The ChartMarker instance.
     #[wasm_bindgen(js_name = "setAutomatic")]
-    pub fn set_automatic(mut self) -> ChartMarker {
+    pub fn set_automatic(&mut self) -> ChartMarker {
         self.inner.set_automatic();
-        self
+        self.clone()
     }
 
     /// Set the formatting properties for a chart marker.
@@ -34,9 +35,9 @@ impl ChartMarker {
     /// @param {ChartFormat} format - The chart format properties.
     /// @return {ChartMarker} - The ChartMarker instance.
     #[wasm_bindgen(js_name = "setFormat")]
-    pub fn set_format(mut self, format: &mut ChartFormat) -> ChartMarker {
+    pub fn set_format(&mut self, format: &mut ChartFormat) -> ChartMarker {
         self.inner.set_format(&mut format.inner);
-        self
+        self.clone()
     }
 
     /// Turn off/hide a chart marker.
@@ -46,9 +47,9 @@ impl ChartMarker {
     ///
     /// @return {ChartMarker} - The ChartMarker instance.
     #[wasm_bindgen(js_name = "setNone")]
-    pub fn set_none(mut self) -> ChartMarker {
+    pub fn set_none(&mut self) -> ChartMarker {
         self.inner.set_none();
-        self
+        self.clone()
     }
 
     /// Set the marker size.
@@ -56,9 +57,9 @@ impl ChartMarker {
     /// @param {number} size - The marker size.
     /// @return {ChartMarker} - The ChartMarker instance.
     #[wasm_bindgen(js_name = "setSize")]
-    pub fn set_size(mut self, size: u8) -> ChartMarker {
+    pub fn set_size(&mut self, size: u8) -> ChartMarker {
         self.inner.set_size(size);
-        self
+        self.clone()
     }
 
     /// Set the marker type.
@@ -66,8 +67,8 @@ impl ChartMarker {
     /// @param {number} marker_type - The marker type.
     /// @return {ChartMarker} - The ChartMarker instance.
     #[wasm_bindgen(js_name = "setType")]
-    pub fn set_type(mut self, marker_type: ChartMarkerType) -> ChartMarker {
+    pub fn set_type(&mut self, marker_type: ChartMarkerType) -> ChartMarker {
         self.inner.set_type(marker_type.into());
-        self
+        self.clone()
     }
 }

--- a/rust/src/wrapper/chart/chart_solid_fill.rs
+++ b/rust/src/wrapper/chart/chart_solid_fill.rs
@@ -11,6 +11,7 @@ use crate::wrapper::color::Color;
 ///
 /// It is used in conjunction with the {@link Chart} struct.
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct ChartSolidFill {
     pub(crate) inner: xlsx::ChartSolidFill,
 }
@@ -30,9 +31,9 @@ impl ChartSolidFill {
     /// @param {Color} color - The color property.
     /// @return {ChartSolidFill} - The ChartSolidFill instance.
     #[wasm_bindgen(js_name = "setColor")]
-    pub fn set_color(mut self, color: &Color) -> ChartSolidFill {
+    pub fn set_color(&mut self, color: &Color) -> ChartSolidFill {
         self.inner.set_color(color.inner);
-        self
+        self.clone()
     }
 
     /// Set the transparency of a solid fill.
@@ -43,8 +44,8 @@ impl ChartSolidFill {
     /// @param {number} transparency - The color transparency in the range 0-100.
     /// @return {ChartSolidFill} - The ChartSolidFill instance.
     #[wasm_bindgen(js_name = "setTransparency")]
-    pub fn set_transparency(mut self, transparency: u8) -> ChartSolidFill {
+    pub fn set_transparency(&mut self, transparency: u8) -> ChartSolidFill {
         self.inner.set_transparency(transparency);
-        self
+        self.clone()
     }
 }

--- a/rust/src/wrapper/chart/mod.rs
+++ b/rust/src/wrapper/chart/mod.rs
@@ -13,6 +13,7 @@ mod chart_series;
 mod chart_solid_fill;
 mod chart_title;
 mod chart_type;
+mod chart_line;
 
 use std::sync::{Arc, Mutex};
 

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -47,7 +47,7 @@ describe("xlsx-wasm test", () => {
   
     const chart = new Chart(ChartType.Stock);
     const chartFont = new ChartFont().setName("Meiryo UI");
-    const chartDataLabel = new ChartDataLabel().setFont(chartFont).showValue().setPosition(ChartDataLabelPosition.Left);
+    const chartDataLabel1 = new ChartDataLabel().setFont(chartFont).showValue().setPosition(ChartDataLabelPosition.Left);
   
     const chartSeries1 = new ChartSeries();
     const chartLine1 = new ChartLine().setColor(Color.green());
@@ -61,22 +61,24 @@ describe("xlsx-wasm test", () => {
       .setCategories(categoriesRange1)
       .setValues(valuesRange1)
       .setFormat(chartFormat1)
-      .setDataLabel(chartDataLabel)
+      .setDataLabel(chartDataLabel1)
       .setMarker(chartMarker1);
+
+    const chartDataLabel2 = new ChartDataLabel();
     const chartSeries2 = new ChartSeries();
-    const chartLine2 = new ChartLine().setColor(Color.purple());
-    const chartSolidFill2 = new ChartSolidFill().setColor(Color.purple());  
-    const chartFormat2 = new ChartFormat().setLine(chartLine2).setSolidFill(chartSolidFill2);
-    const chartMarker2 = new ChartMarker().setType(ChartMarkerType.Diamond).setSize(10).setFormat(chartFormat2);
+    const chartLine2 = new ChartLine();
+    const chartSolidFill2 = new ChartSolidFill();
+    const chartFormat2 = new ChartFormat();
+    const chartMarker2 = new ChartMarker();
     const categoriesRange2 = new ChartRange("Sheet1", 1, 0, 6, 0);
     const valuesRange2 = new ChartRange("Sheet1", 1, 2, 6, 2);
     chartSeries2
       .setName("Score 2")
       .setCategories(categoriesRange2)
       .setValues(valuesRange2)
-      .setFormat(chartFormat2)
-      .setDataLabel(chartDataLabel)
-      .setMarker(chartMarker2);
+      .setFormat(chartFormat2.setLine(chartLine2.setColor(Color.purple())).setSolidFill(chartSolidFill2.setColor(Color.purple())))
+      .setDataLabel(chartDataLabel2.setFont(chartFont).showValue().setPosition(ChartDataLabelPosition.Left))
+      .setMarker(chartMarker2.setType(ChartMarkerType.Diamond).setSize(10).setFormat(chartFormat2.setLine(chartLine2.setColor(Color.purple())).setSolidFill(chartSolidFill2.setColor(Color.purple()))));
     chart
       .pushSeries(chartSeries1)
       .pushSeries(chartSeries2);


### PR DESCRIPTION
As explained in https://github.com/estie-inc/wasm-xlsxwriter/pull/77#discussion_r1991619683
`Chart` types crash when referenced after instantiation

```
Error: Error: null pointer passed to rust
 ❯ imports.wbg.__wbindgen_throw web/wasm_xlsxwriter.js:7124:15
 ❯ null.<anonymous> wasm:/wasm/0053bfca:1:1226006
 ❯ null.<anonymous> wasm:/wasm/0053bfca:1:1226019
 ❯ null.<anonymous> wasm:/wasm/00[53](https://github.com/estie-inc/wasm-xlsxwriter/actions/runs/13917221777/job/38942339826?pr=83#step:6:54)bfca:1:1027008
 ❯ ChartLine.setColor web/wasm_xlsxwriter.js:1911:26
 ❯ test/chart.test.ts:81:118
```

This issue occurs because, in wasm-bindgen, arguments passed as non reference types are discarded after the scope ends.
This PR modifies the chart types to receive `self` as reference.

Also, refactored chart_format and moved chart_line to a separate file.

No API changes in JS.