### PR TITLE
update rust_xlsxwriter 0.86.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "rust_xlsxwriter"
-version = "0.86.0"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce466a17c071a45249477993a1f1b6ceb447af42cbe9cdc65e30f38bab850688"
+checksum = "34ab327483e6b6fc521b7e303691c14bf3624a68e0cb4c2b9f9c5d692e07f637"
 dependencies = [
  "chrono",
  "js-sys",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 chrono = "0.4.40"
 console_error_panic_hook = "0.1.7"
 js-sys = "0.3.77"
-rust_xlsxwriter = { version = "0.86.0", features = ["wasm", "chrono"] }
+rust_xlsxwriter = { version = "0.86.1", features = ["wasm", "chrono"] }
 wasm-bindgen = "0.2.94"


### PR DESCRIPTION
Now that https://github.com/jmcnamara/rust_xlsxwriter/issues/146 has been fixed, we can proceed with the version upgrade.