### PR TITLE
Switch nodejs target to ESM and remove sub-directory package.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 **/target
 /nodejs/
-!/nodejs/package.json
 /web/
-!/web/package.json
 
 **/node_modules
 **/*.xlsx

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,0 @@
-{
-    "name": "wasm-xlsxwriter-nodejs",
-    "main": "wasm_xlsxwriter.js",
-    "types": "wasm_xlsxwriter.d.ts",
-    "type": "commonjs"
-}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "build": "npm run setup && npm run build:wasm && npm run build:web && npm run build:nodejs",
         "build:wasm": "cd rust && cargo build --lib --target wasm32-unknown-unknown --release --target-dir target",
         "build:web": "wasm-bindgen --target web --out-dir web rust/target/wasm32-unknown-unknown/release/wasm_xlsxwriter.wasm && wasm-opt -O web/wasm_xlsxwriter_bg.wasm -o web/wasm_xlsxwriter_bg.wasm",
-        "build:nodejs": "wasm-bindgen --target nodejs --out-dir nodejs rust/target/wasm32-unknown-unknown/release/wasm_xlsxwriter.wasm && wasm-opt -O nodejs/wasm_xlsxwriter_bg.wasm -o nodejs/wasm_xlsxwriter_bg.wasm",
+        "build:nodejs": "wasm-bindgen --target experimental-nodejs-module --out-dir nodejs rust/target/wasm32-unknown-unknown/release/wasm_xlsxwriter.wasm && wasm-opt -O nodejs/wasm_xlsxwriter_bg.wasm -o nodejs/wasm_xlsxwriter_bg.wasm",
         "test": "vitest"
     },
     "devDependencies": {

--- a/test/chart.test.ts
+++ b/test/chart.test.ts
@@ -21,7 +21,7 @@ import {
   ChartPatternFill,
   ChartPatternFillType,
   ChartEmptyCells,
-} from "../web/wasm_xlsxwriter";
+} from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, expect } from "vitest";
 import { initWasModule, readXlsx, readXlsxFile } from "./common";
 

--- a/test/common.ts
+++ b/test/common.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { assert } from "console";
 import unzipper from "unzipper";
-import initWasmBindgen from "../web";
+import initWasmBindgen from "wasm-xlsxwriter/web";
 
 export async function initWasModule() {
   const wasmSource = await fs.promises.readFile("web/wasm_xlsxwriter_bg.wasm");

--- a/test/datetime.test.ts
+++ b/test/datetime.test.ts
@@ -1,4 +1,4 @@
-import { ExcelDateTime } from "../web";
+import { ExcelDateTime } from "wasm-xlsxwriter/web";
 import { describe, test, expect, beforeAll } from "vitest";
 import { initWasModule } from "./common.js";
 

--- a/test/default-format.test.ts
+++ b/test/default-format.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, test } from "vitest";
-import { Format, Image, Workbook } from "../web";
+import { Format, Image, Workbook } from "wasm-xlsxwriter/web";
 import { initWasModule, loadFile, readXlsx, readXlsxFile } from "./common";
 
 beforeAll(async () => {

--- a/test/empty.test.ts
+++ b/test/empty.test.ts
@@ -1,4 +1,4 @@
-import { Workbook } from "../web";
+import { Workbook } from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, expect } from "vitest";
 import { initWasModule, readXlsx, readXlsxFile } from "./common";
 

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -9,7 +9,7 @@ import {
   FormatUnderline,
   Formula,
   Workbook,
-} from "../web";
+} from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, expect } from "vitest";
 import { initWasModule, readXlsx, readXlsxFile } from "./common";
 

--- a/test/image.test.ts
+++ b/test/image.test.ts
@@ -1,4 +1,4 @@
-import { Workbook, Image, ObjectMovement } from "../web";
+import { Workbook, Image, ObjectMovement } from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, expect } from "vitest";
 import { initWasModule, loadFile, readXlsx, readXlsxFile } from "./common";
 

--- a/test/note.test.ts
+++ b/test/note.test.ts
@@ -1,4 +1,4 @@
-import { Color, Format, Note, Workbook, ObjectMovement } from "../web";
+import { Color, Format, Note, Workbook, ObjectMovement } from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, expect } from "vitest";
 import { initWasModule, readXlsx, readXlsxFile } from "./common";
 

--- a/test/panic-hook.test.ts
+++ b/test/panic-hook.test.ts
@@ -1,4 +1,4 @@
-import { Image } from "../web";
+import { Image } from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, beforeEach, afterEach, expect, vi } from "vitest";
 import { initWasModule } from "./common";
 

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -1,4 +1,4 @@
-import { Color, Format, HeaderImagePosition, Image, Workbook } from "../web";
+import { Color, Format, HeaderImagePosition, Image, Workbook } from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, expect } from "vitest";
 import { initWasModule, loadFile, readXlsx, readXlsxFile } from "./common";
 

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,4 +1,4 @@
-import { Workbook, TableFunction, TableColumn, Formula, Table } from "../web";
+import { Workbook, TableFunction, TableColumn, Formula, Table } from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, expect } from "vitest";
 import { initWasModule, readXlsx, readXlsxFile } from "./common";
 

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -1,4 +1,4 @@
-import { Workbook, Format, Formula, RichString } from "../web";
+import { Workbook, Format, Formula, RichString } from "wasm-xlsxwriter/web";
 import { describe, test, beforeAll, expect } from "vitest";
 import { initWasModule, readXlsx, readXlsxFile } from "./common";
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,0 @@
-{
-    "name": "wasm-xlsxwriter-web",
-    "main": "wasm_xlsxwriter.js",
-    "types": "wasm_xlsxwriter.d.ts",
-    "type": "module"
-}


### PR DESCRIPTION
## Summary

- Switch `--target nodejs` (CJS) to `--target experimental-nodejs-module` (ESM) for the nodejs build target
- Use self-referencing package imports (`wasm-xlsxwriter/web`) in tests instead of relative directory imports (`../web`)
- Remove `web/package.json` and `nodejs/package.json` — no longer needed since both targets are ESM (matching root `"type": "module"`) and tests use the root exports map
- Simplify `.gitignore` (no `!*/package.json` exclusion rules)

## Compatibility

- Node.js 22+ supports `require(esm)`, so CJS consumers are unaffected
- This package already declares `"type": "module"` and uses `exports` map, so the consumer-facing API is unchanged
- `experimental-nodejs-module` is a wasm-bindgen target that has been stable and actively maintained since at least 2024. The "experimental" prefix remains but the feature receives continuous improvements (test additions, refactors, output consolidation). If the target name changes in the future, only the `--target` flag in `package.json` needs updating.

## Test plan

- [x] `npm run build` succeeds locally
- [x] `npm test` — 52/52 tests pass
- [x] `npm ci` passes on Linux amd64 (Docker)
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)