### PR TITLE
chore: add 14-day cooldown to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     groups:
       dependencies:
         patterns:
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     groups:
       dependencies:
         patterns:
@@ -20,6 +24,8 @@ updates:
     directory: "/rust"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
## Summary
- Add `cooldown.default-days: 14` to each ecosystem (`github-actions`, `npm`, `cargo`) in `.github/dependabot.yml`.
- Dependabot will now wait 14 days after a new version is released before opening an update PR, per internal policy.

## Background
Internal policy now requires a 2-week cooldown on Dependabot updates to reduce exposure to freshly-published bad releases.

## Test plan
- [ ] Dependabot config validates on GitHub (visible under the repo's Insights → Dependency graph → Dependabot tab).
- [ ] Verify next scheduled Dependabot run respects the cooldown window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)