### PR TITLE
bump version to 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wasm-xlsxwriter",
-    "version": "0.12.2",
+    "version": "0.13.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wasm-xlsxwriter",
-            "version": "0.12.2",
+            "version": "0.13.0",
             "license": "MIT",
             "devDependencies": {
                 "@tsconfig/strictest": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wasm-xlsxwriter",
-    "version": "0.12.2",
+    "version": "0.13.0",
     "type": "module",
     "types": "nodejs/wasm_xlsxwriter.d.ts",
     "exports": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-xlsxwriter"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-xlsxwriter"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 repository = "https://github.com/estie-inc/wasm-xlsxwriter"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps the package version to `0.13.0` in all locations.

The `v0.13.0` tag was pushed without updating `package.json` / `Cargo.toml`, so the `npm publish` workflow failed with:

```
Tag v0.13.0 does not match package.json version (expected 0.12.2)
```

- `package.json` / `package-lock.json`: `0.12.2` → `0.13.0`
- `rust/Cargo.toml` / `rust/Cargo.lock`: `0.12.1` → `0.13.0`

## Follow-up

After merging, re-tag `v0.13.0` on the merge commit (delete the old tag and push the new one) to re-trigger `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)