### PR TITLE
ci: fix playwright install hang on Node 24.16+ and cap job timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -41,6 +42,7 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -55,6 +57,7 @@ jobs:
   test-nextjs:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -73,6 +76,7 @@ jobs:
   test-nodejs:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -90,6 +94,7 @@ jobs:
   test-vite:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -11,7 +11,7 @@
         "wasm-xlsxwriter": "file:../.."
       },
       "devDependencies": {
-        "@playwright/test": "^1.52.0",
+        "@playwright/test": "^1.60.0",
         "@types/node": "25.2.2",
         "@types/react": "19.2.13",
         "typescript": "5.9.3"
@@ -19,7 +19,7 @@
     },
     "../..": {
       "name": "wasm-xlsxwriter",
-      "version": "0.12.2",
+      "version": "0.13.0",
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/strictest": "2.0.8",
@@ -642,13 +642,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -829,13 +829,13 @@
       "license": "ISC"
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -12,7 +12,7 @@
     "wasm-xlsxwriter": "file:../.."
   },
   "devDependencies": {
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "^1.60.0",
     "@types/node": "25.2.2",
     "@types/react": "19.2.13",
     "typescript": "5.9.3"

--- a/examples/vite/package-lock.json
+++ b/examples/vite/package-lock.json
@@ -8,14 +8,14 @@
         "wasm-xlsxwriter": "file:../.."
       },
       "devDependencies": {
-        "@playwright/test": "^1.52.0",
+        "@playwright/test": "^1.60.0",
         "typescript": "5.9.3",
         "vite": "^8.0.8"
       }
     },
     "../..": {
       "name": "wasm-xlsxwriter",
-      "version": "0.12.2",
+      "version": "0.13.0",
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/strictest": "2.0.8",
@@ -93,13 +93,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -750,13 +750,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -11,7 +11,7 @@
     "wasm-xlsxwriter": "file:../.."
   },
   "devDependencies": {
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "^1.60.0",
     "typescript": "5.9.3",
     "vite": "^8.0.8"
   }


### PR DESCRIPTION
## Summary

- Bump `@playwright/test` to `1.60.0` in `examples/nextjs` and `examples/vite` (lockfiles regenerated on Linux).
- Add `timeout-minutes: 15` to every job in `test.yml`.

## Root cause

In recent runs (e.g. #235) the `test-nextjs` and `test-vite` jobs hung for the full **6h (360 min)** before being cancelled. Both stalled at the same point — `npx playwright install chromium --with-deps` — right after the chromium download reached 100%, with zero output afterward.

This is a known Playwright bug. Playwright **< 1.60.0** hangs during chromium archive extraction on **Node 24.16.0+** due to a yauzl stream-destruction regression: the download finishes (100%) and then extraction stalls indefinitely (only the main binary is written, auxiliary files are missing). Tracked in [microsoft/playwright#40724](https://github.com/microsoft/playwright/issues/40724) / [#40998](https://github.com/microsoft/playwright/issues/40998), fixed by vendoring an updated yauzl in **1.60.0** ([microsoft/playwright#40747](https://github.com/microsoft/playwright/pull/40747)).

Nothing changed in our code. The examples were locked to `1.59.1`, and `actions/setup-node` with `node-version: "24.x"` floats to the latest 24.x patch. Once **Node 24.16.0** (released 2026-05-21) became the resolved version, every run began hitting the hang. CI logs confirm it:

| run | Node (from setup-node) | Playwright | result |
|---|---|---|---|
| 2026-05-26 | `24.15.0` | 1.59.1 | pass |
| #235 (2026-06-01) | `24.16.0` | 1.59.1 | hang → cancelled at 360 min |

## Fixes

- **Playwright 1.60.0** is the real fix — it contains the yauzl extraction fix, so the install no longer hangs on Node 24.16+.
- **`timeout-minutes: 15`** is a safety net independent of this bug: all jobs normally finish within ~2 minutes, so any future hang fails fast (360 min → 15 min) instead of holding a runner for the full GitHub default.