### PR TITLE
bump version to 0.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wasm-xlsxwriter",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wasm-xlsxwriter",
-            "version": "0.13.0",
+            "version": "0.13.1",
             "license": "MIT",
             "devDependencies": {
                 "@tsconfig/strictest": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wasm-xlsxwriter",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "type": "module",
     "types": "nodejs/wasm_xlsxwriter.d.ts",
     "exports": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-xlsxwriter"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "console_error_panic_hook",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-xlsxwriter"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 repository = "https://github.com/estie-inc/wasm-xlsxwriter"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps the package version to `0.13.1` in all locations.

- `package.json` / `package-lock.json`: `0.13.0` → `0.13.1`
- `rust/Cargo.toml` / `rust/Cargo.lock`: `0.13.0` → `0.13.1`

## Included since v0.13.0

- feat: add `Chart.combine` and `ChartSeries.setSecondaryAxis` (#235)
- ci: add `timeout-minutes` to test jobs (#236)
- chore(deps): dependency group bumps

## Follow-up

After merging, tag `v0.13.1` on the merge commit and push it to trigger the `npm publish` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)